### PR TITLE
Revise rfc822 decode method

### DIFF
--- a/libearth/codecs.py
+++ b/libearth/codecs.py
@@ -215,15 +215,17 @@ class Rfc822(Codec):
         return res
 
     def decode(self, text):
+        text = text.strip()
         timestamp = text[:25]
         timezone = text[26:]
         try:
             res = datetime.datetime.strptime(timestamp, "%a, %d %b %Y %H:%M:%S")
-            matched = re.match(r'\+([0-9]{2})([0-9]{2})', timezone)
+            matched = re.match(r'([\+\-])([0-9]{2})([0-9]{2})', timezone)
             if matched:
                 offset = FixedOffset(
-                    int(matched.group(1)) * 60 +
-                    int(matched.group(2))
+                    int(matched.group(2)) * 60 +
+                    int(matched.group(3)) *
+                    (1 if matched.group(1) == '+' else -1)
                 )
                 res = res.replace(tzinfo=offset)
             elif timezone in self.TIMEZONES:

--- a/tests/codecs_test.py
+++ b/tests/codecs_test.py
@@ -61,6 +61,26 @@ def test_rfc822():
     assert codec.encode(kst_datetime) == kst_string
 
 
+def test_rfc822_minus_tz():
+    codec = Rfc822()
+    utc_string = 'Sat, 07 Sep 2013 01:20:43 -0000'
+    utc_datetime = datetime.datetime(2013, 9, 7, 1, 20, 43,
+                                     tzinfo=utc)
+
+    assert codec.decode(utc_string) == utc_datetime
+
+
+def test_rfc822_with_white_space():
+    codec = Rfc822()
+    utc_string = '''
+        Sat, 07 Sep 2013 01:20:43 +0000
+    '''
+    utc_datetime = datetime.datetime(2013, 9, 7, 1, 20, 43,
+                                     tzinfo=utc)
+
+    assert codec.decode(utc_string) == utc_datetime
+
+
 def test_rfc822_namedtz():
     codec = Rfc822()
     gmt_string = 'Sat, 07 Sep 2013 01:20:43 GMT'


### PR DESCRIPTION
Now decoding a rfc822 string with minus timezone string or
heading and trailing white spaces works.
