### PR TITLE
Notify travis test status to gitter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,3 +73,9 @@ notifications:
     - "irc.ozinger.org#earthreader"
     on_success: change
     on_failure: always
+  webhooks:
+    urls:
+      - https://webhooks.gitter.im/e/26ec2705d187bac9673e
+    on_success: change
+    on_failure: always
+    on_start: false


### PR DESCRIPTION
This change makes Travis CI notify each build status of libearth
to the Gitter channel: https://gitter.im/earthreader/libearth
