### PR TITLE
Support xhtml

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -21,6 +21,8 @@ To be released.
   - Added :func:`~libearth.parser.base.get_element_id`.
     It returns the string consists of an XML namespace and an element tag that
     :mod:`xml.etree.ElementTree` can recognize when finding children elements.
+  - Support atom feed that :class:`~libearth.feed.Text` with `xhtml` type.
+
 
 - Introduced new :mod:`libearth.defaults` module.
   This module provides small utilities and default data to fill initial state

--- a/libearth/feed.py
+++ b/libearth/feed.py
@@ -39,11 +39,7 @@ class Text(Element):
     #: (:class:`str`) The type of the text.  It could be one of ``'text'``
     #: or ``'html'``.  It corresponds to :rfc:`4287#section-3.1.1` (section
     #: 3.1.1).
-    #:
-    #: .. note::
-    #:
-    #:    It currently does not support ``'xhtml'``.
-    type = Attribute('type', Enum(['text', 'html']),
+    type = Attribute('type', Enum(['text', 'html', 'xhtml']),
                      required=True, default=lambda _: 'text')
 
     #: (:class:`str`) The content of the text.  Interpretation for this
@@ -87,7 +83,7 @@ class Text(Element):
     def __unicode__(self):
         if not self.value:
             return ''
-        elif self.type == 'html':
+        elif self.type in ('html', 'xhtml'):
             return clean_html(self.value)
         elif self.type == 'text':
             return self.value

--- a/libearth/parser/atom.py
+++ b/libearth/parser/atom.py
@@ -14,7 +14,7 @@ except ImportError:
     import urllib.parse as urlparse
 
 from ..codecs import Rfc3339, Rfc822
-from ..compat.etree import fromstring
+from ..compat.etree import fromstring, tostring
 from ..feed import (Category, Content, Entry, Feed, Generator, Link,
                     Person, Source, Text)
 from ..schema import DecodeError
@@ -109,8 +109,9 @@ def parse_text_construct(element, session):
         text.type = text_type
     if text.type in ('text', 'html'):
         text.value = element.text
-    elif text.value == 'xhtml':
-        text.value = ''  # TODO
+    elif text.type == 'xhtml':
+        text.value = tostring(element)
+
     return text, session
 
 

--- a/tests/feed_test.py
+++ b/tests/feed_test.py
@@ -25,6 +25,9 @@ def test_text_str():
     assert text_type(Text(type='html', value='Hello world')) == 'Hello world'
     assert (text_type(Text(type='html', value='<p>Hello <em>world</em></p>')) ==
             'Hello world')
+    assert text_type(Text(type='xhtml', value='Hello world')) == 'Hello world'
+    assert (text_type(Text(type='xhtml', value='<p>Hello <em>world</em></p>')) ==
+            'Hello world')
 
 
 def test_get_sanitized_html():

--- a/tests/feed_test.py
+++ b/tests/feed_test.py
@@ -26,8 +26,9 @@ def test_text_str():
     assert (text_type(Text(type='html', value='<p>Hello <em>world</em></p>')) ==
             'Hello world')
     assert text_type(Text(type='xhtml', value='Hello world')) == 'Hello world'
-    assert (text_type(Text(type='xhtml', value='<p>Hello <em>world</em></p>')) ==
-            'Hello world')
+    assert (
+        text_type(Text(type='xhtml', value='<p>Hello <em>world</em></p>')) ==
+        'Hello world')
 
 
 def test_get_sanitized_html():


### PR DESCRIPTION
Earth Reader can subscribe atom feed which have element with `xhtml` type.